### PR TITLE
一些細節上的修復

### DIFF
--- a/td_rl_pinyin_flypy.schema.yaml
+++ b/td_rl_pinyin_flypy.schema.yaml
@@ -2,18 +2,18 @@
 # encoding: utf-8
 
 schema:
-  schema_id: td_rl_pinyin_flypy
+  schema_id: td_pinyin_flypy
   name: 帶調小鶴雙拼
   version: "0.1"
   author:
     - double pinyin layout by 鶴
-    - edited by myt007
     - Rime schema by 佛振 <chen.sst@gmail.com>
     - zaqzrh
+    - Hydroge
   description: |
     地球拼音＋小鶴雙拼方案。
   dependencies:
-    - stroke
+    #- stroke
 
 switches:
   - name: ascii_mode
@@ -22,7 +22,6 @@ switches:
   - name: full_shape
     states: [ 半角, 全角 ]
   - name: simplification
-    reset: 1
     states: [ 漢字, 汉字 ]
   - name: ascii_punct
     states: [ 。，, ．， ]
@@ -45,11 +44,10 @@ engine:
     - fallback_segmentor
   translators:
     - punct_translator
-    - table_translator@custom_phrase
     - reverse_lookup_translator
     - script_translator
   filters:
-    # - reverse_lookup_filter
+    - reverse_lookup_filter
     - simplifier
     - uniquifier
 
@@ -97,8 +95,8 @@ speller:
 
 translator:
   dictionary: terra_pinyin
-  spelling_hints: 5  # ～字以內候選標註完整帶調拼音
-  prism: td_rl_pinyin_flypy
+  prism: td_pinyin_flypy
+  spelling_hints: 8
   preedit_format:
     - xform/([bpmfdtnljqx])n/$1iao/
     - xform/(\w)g/$1eng/
@@ -113,6 +111,7 @@ translator:
     - xform/(\w)s/$1ong/
     - xform/(\w)d/$1ai/
     - xform/(\w)f/$1en/
+    - xform/[e]h/ê/
     - xform/(\w)h/$1ang/
     - xform/(\w)j/$1an/
     - xform/([gkhvuirzcs])k/$1uai/
@@ -133,9 +132,12 @@ translator:
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
     - xform/([jqxy])v/$1u/
-    - xform/eh/ê/
     - 'xform ([aeiou])(ng?|r)([-;/<,>\\]) $1$3$2'
-    - 'xform ([aeo])([iuo])([-;/<,>\\]) $1$3$2'
+    # - 'xform ([aeo])([iuo])([-;/<,>\\]) $1$3$2'
+    - 'xform ([o])([o])([-;/<,>\\]) $2$1$3'
+    - 'xform ([a])([io])([-;/<,>\\]) $1$3$2'
+    - 'xform ([e])([i])([-;/<,>\\]) $1$3$2'
+    - 'xform ([o])([u])([-;/<,>\\]) $1$3$2'
     - 'xform a[-;] ā'
     - 'xform a/ á'
     - 'xform a[<,] ǎ'
@@ -148,6 +150,23 @@ translator:
     - 'xform o/ ó'
     - 'xform o[<,] ǒ'
     - 'xform o[>\\] ò'
+    # 下述代碼爲aa、oo、ee撰寫爲a、o、e的改良方案，但會降低打字容錯率。
+    # - 'xform (o)(u)([-;/<,>\\]) $1$3$2'
+    # - 'xform a?a[-;] ā'
+    # - 'xform a?a/ á'
+    # - 'xform a?a[<,] ǎ'
+    # - 'xform a?a[>\\] à'
+    # - 'xform a?a a'
+    # - 'xform e?e[-;] ē'
+    # - 'xform e?e/ é'
+    # - 'xform e?e[<,] ě'
+    # - 'xform e?e[>\\] è'
+    # - 'xform e?e e'
+    # - 'xform o?o[-;] ō'
+    # - 'xform o?o/ ó'
+    # - 'xform o?o[<,] ǒ'
+    # - 'xform o?o[>\\] ò'
+    # - 'xform o?o o'
     - 'xform i[-;] ī'
     - 'xform i/ í'
     - 'xform i[<,] ǐ'
@@ -162,46 +181,11 @@ translator:
     - 'xform ü[>\\] ǜ'
   comment_format:
     - xform ([aeiou])(ng?|r)([1234]) $1$3$2
-    - xform ([aeo])([iuo])([1234]) $1$3$2
-    - xform a1 ā
-    - xform a2 á
-    - xform a3 ǎ
-    - xform a4 à
-    - xform e1 ē
-    - xform e2 é
-    - xform e3 ě
-    - xform e4 è
-    - xform o1 ō
-    - xform o2 ó
-    - xform o3 ǒ
-    - xform o4 ò
-    - xform i1 ī
-    - xform i2 í
-    - xform i3 ǐ
-    - xform i4 ì
-    - xform u1 ū
-    - xform u2 ú
-    - xform u3 ǔ
-    - xform u4 ù
-    - xform v1 ǖ
-    - xform v2 ǘ
-    - xform v3 ǚ
-    - xform v4 ǜ
-    - xform/([nljqxy])v/$1ü/
-    - xform/eh[0-5]?/ê/
-    - xform/([a-z]+)[0-5]/$1/
-
-reverse_lookup:
-  dictionary: stroke
-  enable_completion: true
-  prefix: "`"
-  suffix: "'"
-  tips: 〔筆畫〕
-  preedit_format:
-    - xlit/hspnz/一丨丿丶乙/
-  comment_format:
-    - xform ([aeiou])(ng?|r)([1234]) $1$3$2
-    - xform ([aeo])([iuo])([1234]) $1$3$2
+    # - xform ([aeo])([iuo])([1234]) $1$3$2
+    - xform ([o])([o])([1234]) $2$1$3
+    - xform ([a])([io])([1234]) $1$3$2
+    - xform ([e])([i])([1234]) $1$3$2
+    - xform ([o])([u])([1234]) $1$3$2
     - xform a1 ā
     - xform a2 á
     - xform a3 ǎ
@@ -231,15 +215,15 @@ reverse_lookup:
     - xform/([a-z]+)[0-5]/$1/
 
 # reverse_lookup:
-#   dictionary: stroke
-#   enable_completion: true 
-#   prefix: "`"
-#   suffix: "'"
-#   tips: 〔筆畫〕
-#   preedit_format:
-#     - xlit/hspnz/一丨丿丶乙/
-#   comment_format:
-#     - xform/([nl])v/$1ü/
+  # dictionary: stroke
+  # enable_completion: true
+  # prefix: "`"
+  # suffix: "'"
+  # tips: 〔筆畫〕
+  # preedit_format:
+    # - xlit/hspnz/一丨丿丶乙/
+  # comment_format:
+    # - xform/([nl])v/$1ü/
 
 punctuator:
   import_preset: default


### PR DESCRIPTION
可能是版本不同，原來的代碼在新版本的小狼毫是無法正常使用的。我用了主機，也用了虛擬機來測試這個代碼，最初的時候我以為我刪掉或者覆蓋了一些重要的文件，直到我一步步重新安裝的時候，我才發現這就是代碼本身的問題。雖然我不知道問題出在哪裡，但我從原版的帶調小鶴雙拼的代碼文件當中修改出來了一個功能高度相似的版本。

此外，eva 的主題設置文件並不好，因爲在安裝的時候會將原先已經存在的主題全部覆蓋，因此建議原作者換一種安裝方式，而不要直接採用簡單粗暴的文件覆蓋。

以下連結是本人版本的一些小特點，可以參考以下。
https://github.com/Hydroge/Tone-double_pinyin/pull/1